### PR TITLE
Enhance RGB regex check, convert values to int and add logging.

### DIFF
--- a/ultimarc/tools/README.md
+++ b/ultimarc/tools/README.md
@@ -4,10 +4,14 @@ The Ultimarc command line tools can be used to program different Ultimarc USB de
 to the local machine. The command line tools are launched through an integrated launcher command.
 Addtionally Bash autocompletion can be enabled by sourcing the `tools.bash` file in your .bashrc profile.
 
+&nbsp; 
+
 ### Device Matching And Filtering
 If the `--bus` and `--address` arguments are not specified, device configuration changes will be applied 
 to all devices discovered by the tool.  If only the `--bus` argument is specifed, all devices on that 
 bus will be matched.  To target a specific device, the `--bus` and `--address` arguments must be specified.
+
+&nbsp; 
 
 ### Running the tool
 
@@ -27,6 +31,8 @@ To get a list of available tools to run:
 To get help for a specific tool run:
 
 ```ultimarc-cli [TOOL NAME] --help```
+
+&nbsp; 
 
 ### Common Tool Arguments
 
@@ -73,6 +79,7 @@ The Address filter specifics a specific device ID on a bus. The `--bus` argument
 
 ```--address [ADDRESS]```
 
+&nbsp; 
 
 ### USB Button Tool
 
@@ -85,8 +92,8 @@ A tool for managing Ultimarc USB Button devices.
 #### --help
 
 ```
-usage: usb-button [-h] [--debug] [--log-file] [-q] [--bus BUS] [--address ADDRESS] [--set-color INT,INT,INT] [--set-random-color] [--get-color]
-                  [--set-config CONFIG-FILE]
+usage: usb-button [-h] [--debug] [--log-file] [-q] [--bus BUS] [--address ADDRESS] [--set-color INT,INT,INT]
+                  [--set-random-color] [--get-color] [--set-config CONFIG-FILE]
 
 manage usb-button devices.
 

--- a/ultimarc/tools/README.md
+++ b/ultimarc/tools/README.md
@@ -1,0 +1,133 @@
+# Ultimarc Command Line Tools
+
+The Ultimarc command line tools can be used to program different Ultimarc USB devices attached 
+to the local machine. The command line tools are launched through an integrated launcher command.
+Addtionally Bash autocompletion can be enabled by sourcing the `tools.bash` file in your .bashrc profile.
+
+### Device Matching And Filtering
+If the `--bus` and `--address` arguments are not specified, device configuration changes will be applied 
+to all devices discovered by the tool.  If only the `--bus` argument is specifed, all devices on that 
+bus will be matched.  To target a specific device, the `--bus` and `--address` arguments must be specified.
+
+### Running the tool
+
+If you have installed the Ultimarc Python package use this command line to run the tools:
+
+```ultimarc-cli [TOOL NAME]```
+
+If you are running tools from a copy of the Github project use this command line from the `ultimarc` 
+directory:
+
+```python3 -m tools [TOOL NAME] ```
+
+To get a list of available tools to run:
+
+```ultimarc-cli --help``` or ```python3 -m tools --help```
+
+To get help for a specific tool run:
+
+```ultimarc-cli [TOOL NAME] --help```
+
+### Common Tool Arguments
+
+These are the common tool command line arguments.  These options are available for every tool.
+
+#### Help
+
+You can show help for the launcher or each tool by adding the help argument.  No other arguments 
+are allowed when using the help argument.
+
+```-h, --help```
+
+#### Debug
+
+Debugging output can be enabled if the debug argument is added.  The debugging argument can be 
+used with any other tool argument.
+
+```--debug```
+
+#### Log File Output
+
+All output can be written to a log file.  The log file argument can be used with any other argument.
+You may need to wrap the filename value with double quotes if there are spaces in the path or filename.
+The log file is written out to the current directory and will have a `[TOOL].log` suffix.
+
+```--log-file```
+
+#### Quiet Output
+
+All output can be suppressed by using the quiet argument. The quiet argument can be used with any other 
+argument.  
+
+```-q, --quiet```
+
+#### Bus Filter
+
+The Bus filter will tell the tools to search for devices that have specified bus ID.
+
+```--bus [BUS]```
+
+#### Address Filter
+
+The Address filter specifics a specific device ID on a bus. The `--bus` argument must also be set.
+
+```--address [ADDRESS]```
+
+
+### USB Button Tool
+
+A tool for managing Ultimarc USB Button devices.
+
+#### Tool Command Name
+
+```usb-button```
+
+#### --help
+
+```
+usage: usb-button [-h] [--debug] [--log-file] [-q] [--bus BUS] [--address ADDRESS] [--set-color INT,INT,INT] [--set-random-color] [--get-color]
+                  [--set-config CONFIG-FILE]
+
+manage usb-button devices.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --debug               enable debug output
+  --log-file            write output to a log file
+  -q, --quiet           suppress normal output
+  --bus BUS             filter by usb device bus number
+  --address ADDRESS     filter by usb device address number
+  --set-color INT,INT,INT
+                        set usb button color with RGB value
+  --set-random-color    randomly set usb button color
+  --get-color           output current usb button color RGB value
+  --set-config CONFIG-FILE
+                        Set button config from config file.
+```
+
+#### --set-color
+
+Configure a device with a specific color RGB color.  The values must be a comma delimited list 
+of 3 integer values between 0 and 255.
+
+Valid argument values are:
+```
+"123,123,123"
+"RGB(123,123,123)"
+```
+
+#### --set-random-color
+
+Configure the UP button position color with a randomly chosen RGB color.
+
+#### --get-color
+
+Return the currently configured RGB color value for the button UP position.  
+
+Note: Currently returns `RGB(0,0,0)` for devices that have not yet been configured since being 
+plugged in.
+
+#### --set-config
+
+Configure a device using the specified configuration file.  See `examples` directory for an 
+example USB Button configuration JSON file.

--- a/ultimarc/tools/usb_button.py
+++ b/ultimarc/tools/usb_button.py
@@ -22,7 +22,7 @@ _logger = logging.getLogger('ultimarc')
 tool_cmd = _('usb-button')
 tool_desc = _('manage usb-button devices.')
 
-_RGB_STRING_REGEX = "^([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3})+$"
+_RGB_STRING_REGEX = r"^.*?([0-9]{1,3}),\s*?([0-9]{1,3}),\s*?([0-9]{1,3})+.*?$"
 
 
 class USBButtonClass(object):
@@ -53,9 +53,12 @@ class USBButtonClass(object):
         # See if we are setting a color from the command line args.
         if self.args.set_color:
             match = re.match(_RGB_STRING_REGEX, self.args.set_color)
+            red, green, blue = match.groups()
             for dev in devices:
                 with dev as dev_h:
-                    dev_h.set_color(match.groups()[0], match.groups()[1], match.groups()[2])
+                    dev_h.set_color(int(red), int(green), int(blue))
+                    _logger.info(f'{dev.dev_key} ({dev.bus},{dev.address}): ' +
+                                 _('Color') + f': RGB({red},{green},{blue}).')
 
         # Return the current color RGB values.
         elif self.args.get_color:

--- a/ultimarc/tools/usb_button.py
+++ b/ultimarc/tools/usb_button.py
@@ -96,12 +96,14 @@ def run():
     parser = ToolContextManager.get_argparser(tool_cmd, tool_desc)
 
     # --set-color --get-color --load-config --export-config
-    parser.add_argument('--set-color', help=_('set usb button color with RGB value'), type=str, default=None)
+    parser.add_argument('--set-color', help=_('set usb button color with RGB value'), type=str, default=None,
+                        metavar='INT,INT,INT')
     parser.add_argument('--set-random-color', help=_('randomly set usb button color'), default=False,
                         action='store_true')
     parser.add_argument('--get-color', help=_('output current usb button color RGB value'), default=False,
                         action='store_true')
-    parser.add_argument('--set-config', help=_('Set button config from config file.'), type=str, default=None)
+    parser.add_argument('--set-config', help=_('Set button config from config file.'), type=str, default=None,
+                        metavar='CONFIG-FILE')
 
     args = parser.parse_args()
 

--- a/ultimarc/tools/usb_button.py
+++ b/ultimarc/tools/usb_button.py
@@ -4,7 +4,6 @@
 #
 # Tool for managing Ultimarc USB Button devices.
 #
-import json
 import logging
 import os
 import random


### PR DESCRIPTION
RGB regex now supports the following arguments to the --set-color command;
  "123,123,123"
  "123, 123, 123"
  "RGB(123,123,123)"
  "RGB(123, 123,123)"
  "rgb(123,123,123)"