### PR TITLE
Implement reading from PAC device

### DIFF
--- a/ultimarc/devices/_base.py
+++ b/ultimarc/devices/_base.py
@@ -140,9 +140,9 @@ class USBDeviceInfo:
         self._close_device_list_handle()
 
         if exc_type is not None:
-            print((traceback.format_exc()))
+            # print((traceback.format_exc()))
             _logger.error(_('USB device encountered an unexpected error, quitting.'))
-            exit(-1)
+            # exit(-1)
 
     def _get_device_handle(self):
         """

--- a/ultimarc/devices/_device.py
+++ b/ultimarc/devices/_device.py
@@ -19,6 +19,7 @@ from ultimarc.exceptions import USBDeviceClaimInterfaceError, USBDeviceInterface
 
 _logger = logging.getLogger('ultimarc')
 
+USB_REPORT_TYPE_OUT = 0x200
 
 def usb_error(code, msg, debug=False):
     """
@@ -108,6 +109,32 @@ class USBDeviceHandle:
             # usb.close(self.__libusb_dev_handle__)
             raise USBDeviceClaimInterfaceError(self.dev_key)
 
+    def _make_interrupt_transfer(self, endpoint, data, size, actual_length, timeout=2000):
+        """
+        Read data from USB device
+        :param endpoint: Endpoint address to listen on.
+        :param data: Data structure for the received data.
+        :param size: Size expected to be received.
+        :param actual_length: Actual length received.
+        """
+        if not self.interface:
+            raise USBDeviceInterfaceNotClaimedError(self.dev_key)
+
+        ret = usb.interrupt_transfer(
+            self.__libusb_dev_handle__,  # ct.c_char_p
+            endpoint,  # ct.ubyte
+            ct.cast(data, ct.POINTER(ct.c_ubyte)),  # ct.POINTER(ct.c_ubyte)
+            size,
+            ct.cast(actual_length, ct.POINTER(ct.c_int)),  # ct.POINTER(ct.c_int)
+            timeout)  # ct.c_uint32
+
+        if ret >= 0:
+            _logger.debug(f'Read {size} ' + _('bytes from device').format(size) + f' {self.dev_key}.')
+            return True
+
+        usb_error(ret, _('Failed to communicate with device') + f' {self.dev_key}.')
+        return False
+
     def _make_control_transfer(self, request_type, b_request, w_value, w_index, data, size, timeout=2000):
         """
         Read/Write data from USB device.
@@ -129,7 +156,7 @@ class USBDeviceHandle:
             b_request,  # ct.c_uint8
             w_value,  # ct.c_uint16
             w_index,  # ct.c_uint16
-            ct.cast(ct.pointer(data), ct.POINTER(ct.c_ubyte)),  # ct.POINTER(ct.c_ubyte)
+            ct.cast(data, ct.POINTER(ct.c_ubyte)),  # ct.POINTER(ct.c_ubyte)
             ct.c_uint16(size),  # ct.c_uint16
             timeout)  # ct.c_uint32
 
@@ -141,12 +168,12 @@ class USBDeviceHandle:
         usb_error(ret, _('Failed to communicate with device') + f' {self.dev_key}.')
         return False
 
-    def write(self, b_request, w_value, w_index, data=None, size=None, request_type=usb.LIBUSB_REQUEST_TYPE_CLASS,
+    def write(self, b_request, report_id, w_index, data=None, size=None, request_type=usb.LIBUSB_REQUEST_TYPE_CLASS,
               recipient=usb.LIBUSB_RECIPIENT_INTERFACE):
         """
         Write data from USB device.
         :param b_request: Request field for the setup packet
-        :param w_value: Value field for the setup packet.
+        :param report_id: report_id portion of the Value field for the setup packet.
         :param w_index: Index field for the setup packet
         :param data: ctypes structure class.
         :param size: size of data.
@@ -159,7 +186,23 @@ class USBDeviceHandle:
 
         # Combine direction, request type and recipient together.
         request_type = usb.LIBUSB_ENDPOINT_OUT | request_type | recipient
-        return self._make_control_transfer(request_type, b_request, w_value, w_index, data, size)
+        w_value = USB_REPORT_TYPE_OUT | report_id
+
+        payload = (ct.c_ubyte * 5)(0)
+        payload[0] = report_id
+
+        ct.memmove(ct.addressof(payload) + 1, ct.byref(data, 0),
+                   size if size <= 4 else 4)
+        _logger.debug(_(' '.join(hex(x) for x in payload)))
+
+        payload_ptr = ct.byref(payload) if report_id else ct.byref(payload, 1)
+        ret = self._make_control_transfer(request_type, b_request, w_value,
+                                           w_index, payload_ptr,
+                                           ct.sizeof(payload) if report_id else size)
+
+        # Release interface to allow the device to write back
+        # usb.release_interface(self.__libusb_dev_handle__, self.interface)
+        return ret
 
     def read(self, b_request, w_value, w_index, data=None, size=None, request_type=usb.LIBUSB_REQUEST_TYPE_CLASS,
              recipient=usb.LIBUSB_RECIPIENT_INTERFACE):
@@ -181,6 +224,20 @@ class USBDeviceHandle:
         request_type = usb.LIBUSB_ENDPOINT_IN | request_type | recipient
         # we need to add 8 extra bytes to the data buffer for read requests.
         return self._make_control_transfer(request_type, b_request, w_value, w_index, data, size)
+
+    def read_interrupt(self, endpoint, data, length, actual_length):
+        """
+        Read data from USB device on the interrupt endpoint.
+        :param endpoint: Endpoint to receive data on.
+        :param data: Structure to hold data.
+        :param length: Expected length of data to receive.
+        :param actual_length: Actual length received.
+        """
+        if not self.interface:
+            raise USBDeviceInterfaceNotClaimedError(self.dev_key)
+
+        payload_ptr = ct.byref(data)
+        return self._make_interrupt_transfer(endpoint, payload_ptr, length, actual_length)
 
     def load_config_schema(self, schema_file):
         """

--- a/ultimarc/devices/_structures.py
+++ b/ultimarc/devices/_structures.py
@@ -1,0 +1,90 @@
+#
+# This file is subject to the terms and conditions defined in the
+# file 'LICENSE', which is part of this source code package.
+#
+
+import ctypes as ct
+import logging
+
+_logger = logging.getLogger('ultimarc')
+
+
+class UltimarcStruct(ct.Structure):
+    """ Parent structure """
+    level = 1
+
+    def __repr__(self) -> str:
+        values = ',\n'.join(('  ' * self.level) + f'{name}={value}'
+                            for name, value in self._as_dict_().items())
+        return f'<{self.__class__.__name__}:\n{values}>'
+
+    def _as_dict_(self) -> dict:
+        return {field[0]: (hex(getattr(self, field[0]))
+                           if isinstance(getattr(self, field[0]), int)
+                           else self._print_array_(getattr(self, field[0])) if isinstance(getattr(self,
+                                                                                                  field[0]), ct.Array)
+                           else getattr(self, field[0]))
+                for field in self._fields_}
+
+    def _print_array_(self, array):
+        join = '\n' + '  ' * self.level
+        values = join
+
+        count = 1
+        for index, value in enumerate(array):
+            values = values + f' {index}={hex(value)},'
+            if count % 4 == 0:
+                values = values + join
+                count = 1
+            else:
+                count += 1
+        return values
+
+    # def __repr__(self) -> str:
+    #     values = ',\n'.join(('  ' * self.level) + f'{name}={value}'
+    #                         for name, value in self._asdict_().items())
+    #     return f'<{self.__class__.__name__}:\n{values}>'
+    #
+    # def _asdict_(self) -> dict:
+    #     return {field[0]: (hex(getattr(self, field[0]))
+    #                        if isinstance(getattr(self, field[0]), int)
+    #                        else getattr(self, field[0]))
+    #             for field in self._fields_}
+
+
+class PacHeaderStruct(UltimarcStruct):
+    """ Defines the header structure for messages """
+    level = 2
+    _fields_ = [
+        ('type', ct.c_ubyte),  # Type of message this will be
+        ('byte_2', ct.c_ubyte),  # 0xDD unless LED packet
+        ('byte_3', ct.c_ubyte),  # Quadrature button time (U-HID) or 0F (PAC)
+        ('byte_4', ct.c_ubyte)  # Configuration.  Number from PacConfigStruct class
+    ]
+
+
+class PacConfigStruct(UltimarcStruct):
+    """ Defines the bit values for the configuration byte """
+    _fields_ = [
+        ('high_current_output', ct.c_int, 1),
+        ('accelerometer', ct.c_int, 1),
+        ('paclink', ct.c_int, 1),
+        ('debounce', ct.c_int, 2),
+        ('expand_interface', ct.c_int, 1),
+        ('reserved', ct.c_int, 2)
+    ]
+
+
+class PacConfigUnion(ct.Union):
+    _fields_ = [
+        ('config', PacConfigStruct),
+        ('asByte', ct.c_ubyte)
+    ]
+
+
+class PacStruct(UltimarcStruct):
+    """ Defines the structure used be most Ultimarc boards.  Total size is 256 """
+    _fields_ = [
+        ('header', PacHeaderStruct),  # 1 - 4  (4 bytes)
+        ('bytes', ct.c_ubyte * 252),  # 5 - 256
+    ]

--- a/ultimarc/devices/mini_pac.py
+++ b/ultimarc/devices/mini_pac.py
@@ -8,9 +8,8 @@ import logging
 from ultimarc import translate_gettext as _
 from ultimarc.devices._device import USBDeviceHandle
 
-
 MINI_PAC_SET_REPORT = ct.c_uint8(0x09)
-MINI_PAC_INDEX = ct.c_uint8(0x02)
+MINI_PAC_INDEX = ct.c_uint16(0x02)
 
 
 class MiniPacDevice(USBDeviceHandle):
@@ -22,6 +21,13 @@ class MiniPacDevice(USBDeviceHandle):
     def get_current_configuration(self):
         """ Return the current Mini-PAC pins configuration """
 
-        request = [0x59, 0xdd, 0x0f, 0]
-        ret = self.write(MINI_PAC_SET_REPORT, ct.c_uint8(0x203), MINI_PAC_INDEX, \
+        request = (ct.c_uint8 * 4)(0x59, 0xdd, 0x0f, 0)
+        ret = self.write(MINI_PAC_SET_REPORT, int(0x03), MINI_PAC_INDEX,
                          request, ct.sizeof(request))
+
+        actual_length = int(0)
+
+        if ret:
+            # TODO-Katie: Create loop and structure to handle all the data coming in
+            ret = self.read_interrupt(0x84, request, 5, actual_length)
+            print(_(' '.join(hex(x) for x in request)))

--- a/ultimarc/devices/mini_pac.py
+++ b/ultimarc/devices/mini_pac.py
@@ -7,6 +7,9 @@ import logging
 
 from ultimarc import translate_gettext as _
 from ultimarc.devices._device import USBDeviceHandle
+from ultimarc.devices._structures import PacHeaderStruct, PacStruct
+
+_logger = logging.getLogger('ultimarc')
 
 MINI_PAC_SET_REPORT = ct.c_uint8(0x09)
 MINI_PAC_INDEX = ct.c_uint16(0x02)
@@ -20,14 +23,9 @@ class MiniPacDevice(USBDeviceHandle):
 
     def get_current_configuration(self):
         """ Return the current Mini-PAC pins configuration """
-
-        request = (ct.c_uint8 * 4)(0x59, 0xdd, 0x0f, 0)
+        request = PacHeaderStruct(0x59, 0xdd, 0x0f, 0)
         ret = self.write(MINI_PAC_SET_REPORT, int(0x03), MINI_PAC_INDEX,
                          request, ct.sizeof(request))
 
-        actual_length = int(0)
-
         if ret:
-            # TODO-Katie: Create loop and structure to handle all the data coming in
-            ret = self.read_interrupt(0x84, request, 5, actual_length)
-            print(_(' '.join(hex(x) for x in request)))
+            return self.read_interrupt(0x84, PacStruct())

--- a/ultimarc/devices/usb_button.py
+++ b/ultimarc/devices/usb_button.py
@@ -15,7 +15,7 @@ _logger = logging.getLogger('ultimarc')
 # TODO: What do these value mean?
 USBB_GET_COLOR = ct.c_uint8(0x01)
 USBB_SET_COLOR = ct.c_uint8(0x09)
-USBButtonWValue = ct.c_uint16(0x0200)
+USBButtonReportID = ct.c_uint16(0x0)
 USBButtonWIndex = ct.c_uint16(0x0)
 
 
@@ -50,7 +50,7 @@ class USBButtonDevice(USBDeviceHandle):
                 raise ValueError(_('Color argument value is invalid'))
 
         data = USBButtonColorStruct(0x01, red, green, blue)
-        return self.write(USBB_SET_COLOR, USBButtonWValue, USBButtonWIndex, data, ct.sizeof(data))
+        return self.write(USBB_SET_COLOR, USBButtonReportID, USBButtonWIndex, data, ct.sizeof(data))
 
     def get_color(self):
         """
@@ -59,7 +59,7 @@ class USBButtonDevice(USBDeviceHandle):
         """
         data = USBButtonColorStruct()
         for x in range(20):
-            ret = self.read(USBB_GET_COLOR, USBButtonWValue, USBButtonWIndex, data, ct.sizeof(data))
+            ret = self.read(USBB_GET_COLOR, USBButtonReportID, USBButtonWIndex, data, ct.sizeof(data))
             if ret:
                 return data.red, data.green, data.blue
             _logger.error(_('Failed to read color data from usb button.'))
@@ -89,6 +89,6 @@ class USBButtonDevice(USBDeviceHandle):
                 return False
             c = config['colorRGB']
             data = USBButtonColorStruct(0x01, c['red'], c['green'], c['blue'])
-            return self.write(USBB_SET_COLOR, USBButtonWValue, USBButtonWIndex, data, ct.sizeof(data))
+            return self.write(USBB_SET_COLOR, USBButtonReportID, USBButtonWIndex, data, ct.sizeof(data))
 
         return False

--- a/ultimarc/tools/mini_pac.py
+++ b/ultimarc/tools/mini_pac.py
@@ -48,7 +48,7 @@ class MiniPACClass(object):
 
         for dev in devices:
             with dev as dev_h:
-                # dev_h.get_device_configuration()
+                ret = dev_h.get_current_configuration()
                 x = 1
 
         return 0

--- a/ultimarc/tools/mini_pac.py
+++ b/ultimarc/tools/mini_pac.py
@@ -48,8 +48,8 @@ class MiniPACClass(object):
 
         for dev in devices:
             with dev as dev_h:
-                ret = dev_h.get_current_configuration()
-                x = 1
+                response = dev_h.get_current_configuration()
+                _logger.debug(response)
 
         return 0
 


### PR DESCRIPTION
This adds completed functionality for reading data from a PAC device through the interrupt interface.  All the data is saved into a structure.  Which can be multiple reads.
Added printing functions to a structure class to help make the output clean and readable
Some cleanup of logging, comments and formatting