### PR TITLE
UI Details Page

### DIFF
--- a/ultimarc/qml/complex/DelegateImage.qml
+++ b/ultimarc/qml/complex/DelegateImage.qml
@@ -176,7 +176,7 @@ Item {
         cursorShape: Qt.PointingHandCursor
         function action() {
             imageList.currentIndex = index
-            imageList.stepForward(release.index)
+            imageList.stepForward(deviceListView.index)
         }
         onClicked: {
             action()

--- a/ultimarc/qml/complex/DelegateImage.qml
+++ b/ultimarc/qml/complex/DelegateImage.qml
@@ -81,7 +81,8 @@ Item {
                 QQC2.Label {
                     verticalAlignment: Text.AlignBottom
 //                    For debugging
-//                    text: " Count: " + deviceListView.count +
+//                    text: " Index: " + index +
+//                          " Count: " + deviceListView.count +
 //                          " isTop: " + isTop +
 //                          " isBottom: " + isBottom +
 //                          " category: '" + model.category +
@@ -89,7 +90,7 @@ Item {
                       text: model.device_class
                 }
                 QQC2.Label {
-//                    text: " " + model.product_name
+                    text: " " + model.product_name
                     visible: model.connected
                    }
             }
@@ -176,7 +177,7 @@ Item {
         cursorShape: Qt.PointingHandCursor
         function action() {
             imageList.currentIndex = index
-            imageList.stepForward(deviceListView.index)
+            imageList.stepForward(index)
         }
         onClicked: {
             action()

--- a/ultimarc/qml/main.qml
+++ b/ultimarc/qml/main.qml
@@ -133,7 +133,7 @@ ApplicationWindow {
                 }
                 Connections {
                     target: contentLoader.item
-                    onStepForward: {
+                    function onStepForward(index) {
                         contentList.currentIndex++
                         canGoBack = true
                         releases.selectedIndex = index

--- a/ultimarc/qml/main.qml
+++ b/ultimarc/qml/main.qml
@@ -136,7 +136,7 @@ ApplicationWindow {
                     function onStepForward(index) {
                         contentList.currentIndex++
                         canGoBack = true
-                        releases.selectedIndex = index
+                        _devices.selected_index = index
                     }
                 }
             }

--- a/ultimarc/qml/views/ImageDetails.qml
+++ b/ultimarc/qml/views/ImageDetails.qml
@@ -69,12 +69,12 @@ Item {
         Item {
             x: mainWindow.margin
             implicitWidth: root.width - 2 * mainWindow.margin
-            implicitHeight: childrenRect.height + Math.round(units.gridUnit * 3.5) + units.gridUnit * 2
+            implicitHeight: childrenRect.height + Math.round(_units.grid_unit * 3.5) + _units.grid_unit * 2
 
             ColumnLayout {
-                y: units.gridUnit
+                y: _units.grid_unit
                 width: parent.width
-                spacing: units.largeSpacing * 3
+                spacing: _units.large_spacing * 3
 
                 RowLayout {
                     id: tools
@@ -107,14 +107,14 @@ Item {
 
                 RowLayout {
                     z: 1 // so the popover stays over the text below
-                    spacing: units.largeSpacing
+                    spacing: _units.large_spacing
                     Item {
-                        Layout.preferredWidth: Math.round(units.gridUnit * 3.5) + units.gridUnit
-                        Layout.preferredHeight: Math.round(units.gridUnit * 3.5)
+                        Layout.preferredWidth: Math.round(_units.grid_unit * 3.5) + _units.grid_unit
+                        Layout.preferredHeight: Math.round(_units.grid_unit * 3.5)
                         Layout.alignment: Qt.AlignHCenter
                         IndicatedImage {
                             anchors.fill: parent
-                            x: units.gridUnit
+                            x: _units.grid_unit
                             source: releases.selected.icon ? releases.selected.icon: ""
                             fillMode: Image.PreserveAspectFit
                             sourceSize.width: parent.width
@@ -123,7 +123,7 @@ Item {
                     }
                     ColumnLayout {
                         Layout.fillHeight: true
-                        spacing: units.largeSpacing
+                        spacing: _units.large_spacing
                         RowLayout {
                             Layout.fillWidth: true
                             QQC2.Label {
@@ -157,7 +157,7 @@ Item {
                         }
                         ColumnLayout {
                             width: parent.width
-                            spacing: units.largeSpacing
+                            spacing: _units.large_spacing
                             opacity: releases.selected.isLocal ? 0.0 : 1.0
                             QQC2.Label {
                                 font.pointSize: referenceLabel.font.pointSize + 1
@@ -205,7 +205,7 @@ Item {
                                     // TODO: Adwaita themed component
                                     QQC2.BusyIndicator {
                                         anchors.right: parent.left
-                                        anchors.rightMargin: units.smallSpacing
+                                        anchors.rightMargin: _units.small_spacing
                                         anchors.verticalCenter: parent.verticalCenter
                                         height: 24
                                         width: 24
@@ -233,7 +233,7 @@ Item {
                                         anchors {
                                             horizontalCenter: parent.horizontalCenter
                                             top: parent.bottom
-                                            topMargin: units.smallSpacing + opacity * units.gridUnit
+                                            topMargin: _units.small_spacing + opacity * _units.grid_unit
                                         }
 
                                         onOpenChanged: {
@@ -243,7 +243,7 @@ Item {
                                         }
 
                                         ColumnLayout {
-                                            spacing: units.largeSpacing
+                                            spacing: _units.large_spacing
 
                                             Repeater {
                                                 id: versionRepeater
@@ -322,7 +322,7 @@ Item {
                                         anchors {
                                             horizontalCenter: parent.horizontalCenter
                                             top: parent.bottom
-                                            topMargin: units.smallSpacing + opacity * units.gridUnit
+                                            topMargin: _units.small_spacing + opacity * _units.grid_unit
                                         }
 
                                         onOpenChanged: {
@@ -332,7 +332,7 @@ Item {
                                         }
 
                                         ColumnLayout {
-                                            spacing: units.largeSpacing
+                                            spacing: _units.large_spacing
 
                                             Repeater {
                                                 model: releases.selected.version.variants

--- a/ultimarc/qml/views/ImageDetails.qml
+++ b/ultimarc/qml/views/ImageDetails.qml
@@ -26,7 +26,7 @@ import "../simple"
 import "../complex"
 
 Item {
-    id: root
+    id: device_details
     anchors.fill: parent
 
     property bool focused: contentList.currentIndex === 1
@@ -39,8 +39,6 @@ Item {
         }
 
     function toMainScreen() {
-        archPopover.open = false
-        versionPopover.open = false
         canGoBack = false
         contentList.currentIndex--
     }
@@ -65,7 +63,7 @@ Item {
 
         Item {
             x: mainWindow.margin
-            implicitWidth: root.width - 2 * mainWindow.margin
+            implicitWidth: device_details.width - 2 * mainWindow.margin
             implicitHeight: childrenRect.height + Math.round(_units.grid_unit * 3.5) + _units.grid_unit * 2
 
             ColumnLayout {
@@ -112,7 +110,9 @@ Item {
                         IndicatedImage {
                             anchors.fill: parent
                             x: _units.grid_unit
-                            source: _devices.selected_icon ? _devices.selected_icon: ""
+                            source: { _devices.selected_index
+                                      _devices.get_property("ICON") ? _devices.get_property("ICON") : ""
+                                    }
                             fillMode: Image.PreserveAspectFit
                             sourceSize.width: parent.width
                             sourceSize.height: parent.height
@@ -126,13 +126,17 @@ Item {
                             QQC2.Label {
                                 Layout.fillWidth: true
                                 font.pointSize: referenceLabel.font.pointSize + 4
-                                text: {_devices.selected_product_name !== "Unknown Name" ? _devices.selected_product_name :
-                                       _devices.selected_device_class
-                                      }
+                                text: { _devices.selected_index
+                                        _devices.get_property("PRODUCT_NAME") !== "Unknown Name" ?
+                                                           _devices.get_property("PRODUCT_NAME") :
+                                                           _devices.get_property("DEVICE_CLASS")
+                                }
                             }
                             QQC2.Label {
                                 font.pointSize: referenceLabel.font.pointSize + 2
-                                text: _devices.selected_device_class
+                                text: {_devices.selected_index
+                                       _devices.get_property("DEVICE_CLASS")
+                                      }
                                 opacity: 0.6
                             }
                         }
@@ -141,8 +145,12 @@ Item {
                             spacing: _units.large_spacing
                             QQC2.Label {
                                 font.pointSize: referenceLabel.font.pointSize + 1
-                                visible: _devices.selected_connected
-                                text: _devices.selected_product_key
+                                visible: {_devices.selected_index
+                                          _devices.get_property("CONNECTED")
+                                }
+                                text: {_devices.selected_index
+                                       _devices.get_property("PRODUCT_KEY")
+                                }
                                 opacity: 0.6
                             }
                             QQC2.Label {

--- a/ultimarc/qml/views/ImageList.qml
+++ b/ultimarc/qml/views/ImageList.qml
@@ -29,11 +29,10 @@ FocusScope {
 
     property alias currentIndex: deviceListView.currentIndex
     property real fadeDuration: 200
-    property int lastIndex: -1
 
     property bool focused: contentList.currentIndex === 0
     signal stepForward(int index)
-    function onStepForward() {lastIndex = index}
+
     enabled: focused
 
     anchors.fill: parent

--- a/ultimarc/qml/views/ImageList.qml
+++ b/ultimarc/qml/views/ImageList.qml
@@ -33,7 +33,7 @@ FocusScope {
 
     property bool focused: contentList.currentIndex === 0
     signal stepForward(int index)
-    onStepForward: lastIndex = index
+    function onStepForward() {lastIndex = index}
     enabled: focused
 
     anchors.fill: parent

--- a/ultimarc/ui/devices_filter_proxy_model.py
+++ b/ultimarc/ui/devices_filter_proxy_model.py
@@ -61,10 +61,14 @@ class DevicesFilterProxyModel(QSortFilterProxyModel, QObject):
     _changed_front_page_ = Signal(bool)
     _changed_filter_class_ = Signal(str)
     _changed_filter_text_ = Signal(str)
+    _changed_device_property_ = Signal(object)
+    _changed_selected_index_ = Signal(int)
+    _changed_selected_ = Signal()
 
     _front_page_ = True
     _filter_text_ = ''
     _filter_class_ = 0
+    _selected_index_ = -1
 
     def __init__(self):
         super().__init__()
@@ -96,8 +100,40 @@ class DevicesFilterProxyModel(QSortFilterProxyModel, QObject):
             self._changed_filter_class_.emit(self._filter_class_)
             self.invalidateFilter()
 
+    def set_selected_index(self, row):
+        if self._selected_index_ != row:
+            model_index = self.sourceModel().index(row, 0)
+            self._selected_index_ = row
+            self._changed_selected_.emit()
+
+    def get_selected_property(self, value):
+        index = self.sourceModel().index(self._selected_index_, 0)
+        # _logger.debug(
+        #    f'proxy: get_selected_property: {value.name}, {index.data(value)}')
+        return index.data(value)
+
+    def get_selected_product_name(self):
+        return self.get_selected_property(DeviceRoles.PRODUCT_NAME)
+
+    def get_selected_icon(self):
+        return self.get_selected_property(DeviceRoles.ICON)
+
+    def get_selected_device_class(self):
+        return self.get_selected_property(DeviceRoles.DEVICE_CLASS)
+
+    def get_selected_connected(self):
+        return self.get_selected_property(DeviceRoles.CONNECTED)
+
+    def get_selected_product_key(self):
+        return self.get_selected_property(DeviceRoles.PRODUCT_KEY)
+
+    selected_device_class = Property(str, get_selected_device_class, notify=_changed_selected_)
+    selected_connected = Property(bool, get_selected_connected, notify=_changed_selected_)
+    selected_icon = Property(str, get_selected_icon, notify=_changed_selected_)
+    selected_product_name = Property(str, get_selected_product_name, notify=_changed_selected_)
+    selected_product_key = Property(str, get_selected_product_key, notify=_changed_selected_)
+    selected_index = Property(int, fset=set_selected_index, notify=_changed_selected_)
     front_page = Property(bool, get_front_page, set_front_page, notify=_changed_front_page_)
-    filter_class = Property(str, get_filter_class, set_filter_class, notify=_changed_filter_class_)
     filter_text = Property(str, get_filter_text, set_filter_text, notify=_changed_filter_text_)
 
     def filterAcceptsRow(self, source_row, source_parent: QModelIndex):
@@ -111,10 +147,8 @@ class DevicesFilterProxyModel(QSortFilterProxyModel, QObject):
             else:
                 product_name = index.data(DeviceRoles.PRODUCT_NAME)
                 device_class = index.data(DeviceRoles.DEVICE_CLASS)
-                device_class_id = index.data(DeviceRoles.DEVICE_CLASS_ID)
                 product_key = index.data(DeviceRoles.PRODUCT_KEY)
 
-                cb_filter = device_class_id == self._filter_class_
                 re_name = re.search(self._filter_text_, product_name, re.IGNORECASE) is not None
                 re_class = re.search(self._filter_text_, device_class, re.IGNORECASE) is not None
                 re_key = re.search(self._filter_text_, product_key, re.IGNORECASE) is not None

--- a/ultimarc/ui/devices_filter_proxy_model.py
+++ b/ultimarc/ui/devices_filter_proxy_model.py
@@ -5,7 +5,7 @@
 import logging
 import re
 
-from PySide6.QtCore import Property, Signal, QModelIndex, QObject, QSortFilterProxyModel
+from PySide6.QtCore import Property, Signal, QModelIndex, QObject, QSortFilterProxyModel, Slot
 
 from ultimarc.ui.devices_model import DeviceRoles
 
@@ -61,9 +61,7 @@ class DevicesFilterProxyModel(QSortFilterProxyModel, QObject):
     _changed_front_page_ = Signal(bool)
     _changed_filter_class_ = Signal(str)
     _changed_filter_text_ = Signal(str)
-    _changed_device_property_ = Signal(object)
-    _changed_selected_index_ = Signal(int)
-    _changed_selected_ = Signal()
+    _changed_selected_index_ = Signal()
 
     _front_page_ = True
     _filter_text_ = ''
@@ -102,37 +100,19 @@ class DevicesFilterProxyModel(QSortFilterProxyModel, QObject):
 
     def set_selected_index(self, row):
         if self._selected_index_ != row:
-            model_index = self.sourceModel().index(row, 0)
             self._selected_index_ = row
-            self._changed_selected_.emit()
+            self._changed_selected_index_.emit()
 
-    def get_selected_property(self, value):
+    def get_selected_index(self):
+        return self._selected_index_
+
+    @Slot(str, result=str)
+    def get_property(self, p):
         index = self.sourceModel().index(self._selected_index_, 0)
-        # _logger.debug(
-        #    f'proxy: get_selected_property: {value.name}, {index.data(value)}')
-        return index.data(value)
+        # _logger.debug(f'get_property slot: {p}, {DeviceRoles[p]}, {index.data(DeviceRoles[p])}')
+        return index.data(DeviceRoles[p])
 
-    def get_selected_product_name(self):
-        return self.get_selected_property(DeviceRoles.PRODUCT_NAME)
-
-    def get_selected_icon(self):
-        return self.get_selected_property(DeviceRoles.ICON)
-
-    def get_selected_device_class(self):
-        return self.get_selected_property(DeviceRoles.DEVICE_CLASS)
-
-    def get_selected_connected(self):
-        return self.get_selected_property(DeviceRoles.CONNECTED)
-
-    def get_selected_product_key(self):
-        return self.get_selected_property(DeviceRoles.PRODUCT_KEY)
-
-    selected_device_class = Property(str, get_selected_device_class, notify=_changed_selected_)
-    selected_connected = Property(bool, get_selected_connected, notify=_changed_selected_)
-    selected_icon = Property(str, get_selected_icon, notify=_changed_selected_)
-    selected_product_name = Property(str, get_selected_product_name, notify=_changed_selected_)
-    selected_product_key = Property(str, get_selected_product_key, notify=_changed_selected_)
-    selected_index = Property(int, fset=set_selected_index, notify=_changed_selected_)
+    selected_index = Property(int, get_selected_index, set_selected_index, notify=_changed_selected_index_)
     front_page = Property(bool, get_front_page, set_front_page, notify=_changed_front_page_)
     filter_text = Property(str, get_filter_text, set_filter_text, notify=_changed_filter_text_)
 

--- a/ultimarc/ui/devices_model.py
+++ b/ultimarc/ui/devices_model.py
@@ -6,7 +6,7 @@ import logging
 from collections import OrderedDict
 
 from enum import IntEnum
-from PySide6.QtCore import QAbstractListModel, QModelIndex, QObject, Property
+from PySide6.QtCore import QAbstractListModel, QModelIndex, QObject, Property, Signal
 
 from ultimarc.devices import DeviceClassID
 from ultimarc.tools import ToolEnvironmentObject
@@ -30,8 +30,8 @@ class DeviceRoles(IntEnum):
 DeviceRolePropertyMap = OrderedDict(zip(list(DeviceRoles), [k.name.lower() for k in DeviceRoles]))
 
 
-class UIDeviceInfo:
-    """ Class fpr holding additional device data for the UI """
+class UIDeviceInfo():
+    """ Class for holding additional device data for the UI """
     product_name = ''
     device_class = ''
     device_class_id = None
@@ -68,7 +68,7 @@ class DevicesModel(QAbstractListModel, QObject):
 
         self.args = args
         self.env = env
-        self._device_count = self.env.devices.device_count
+        self._device_count_ = self.env.devices.device_count
         self._category_ = 'Ultimarc Configurations'
         self._ui_dev_info_ = []
 
@@ -110,7 +110,7 @@ class DevicesModel(QAbstractListModel, QObject):
             return None
 
         if role == DeviceRoles.CATEGORY:
-            return 'main' if index.row() < self._device_count else self._category_
+            return 'main' if index.row() < self._device_count_ else self._category_
 
         for x in range(len(self._ui_dev_info_)):
             if x == index.row():
@@ -126,7 +126,7 @@ class DevicesModel(QAbstractListModel, QObject):
         return self._category_
 
     def get_device_count(self):
-        return self._device_count if self._device_count < 4 else 4
+        return self._device_count_ if self._device_count_ < 4 else 4
 
     device_count = Property(int, get_device_count, constant=True)
     category = Property(str, get_category, constant=True)


### PR DESCRIPTION
After thinking about how to get the information to the details page.  This functionality I think is the way it will have to happen.  The Details page is outside the model view delegate so each item has be asked for through Properties to access the model data at the correct index.  The Properties have to be implemented at the proxy model so the indexes are correctly sorted out between the proxy models and the actual model.

If you can see a better way or more Pythonic way, let me know.