### PR TITLE
Fix issues with running on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,11 @@ To install both the command line and graphical tools, run:
 
     $ pip install ultimarc[ui]
 
+Installing on Windows
+::
+
+Install Python 3 from `Python.org <https://www.python.org/>`_.  The Python available through the
+Microsoft Store doesn't have all the required dll's to run the Graphical Tool.
 
 Graphical Tool
 ==============
@@ -135,4 +140,4 @@ Project Links
 License
 =======
 
-GPL-3.0 licensed. See the bundled `LICENSE <https://github.com/katie-snow/QtPyUltimarc/blob/main/LICENSE>` file for more details.
+GPL-3.0 licensed. See the bundled `LICENSE <https://github.com/katie-snow/QtPyUltimarc/blob/main/LICENSE>`_ file for more details.

--- a/tests/devices/test_ipac2.py
+++ b/tests/devices/test_ipac2.py
@@ -3,8 +3,8 @@
 # file 'LICENSE', which is part of this source code package.
 #
 import json
-import os
 
+from pathlib import Path
 from unittest.mock import patch
 from unittest import TestCase
 
@@ -25,10 +25,10 @@ class Ipac2DeviceTest(TestCase):
         """ This is called before every test method in the test class """
         super(Ipac2DeviceTest, self).setUp()
 
-        schema_file = os.path.join(git_project_root(), 'ultimarc/schemas/ipac2.schema')
-        self.assertTrue(os.path.exists(schema_file))
-        config_file = os.path.join(git_project_root(), 'ultimarc/examples/ipac2.json')
-        self.assertTrue(os.path.exists(config_file))
+        schema_file = Path(git_project_root()) / 'ultimarc/schemas/ipac2.schema'
+        self.assertTrue(schema_file.is_file())
+        config_file = Path(git_project_root()) / 'ultimarc/examples/ipac2.json'
+        self.assertTrue(config_file.is_file())
 
         # https://python-jsonschema.readthedocs.io/en/stable/
         with open(schema_file) as h:
@@ -45,7 +45,7 @@ class Ipac2DeviceTest(TestCase):
 
         dev.__class__ = Ipac2Device
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/ipac2/ipac2-good.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/ipac2/ipac2-good.json'
         valid, data = dev._create_device_message_(config_file)
         # print(data)
         self.assertTrue(valid)
@@ -131,7 +131,7 @@ class Ipac2DeviceTest(TestCase):
 
         dev.__class__ = Ipac2Device
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/ipac2/ipac2-pin-optional.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/ipac2/ipac2-pin-optional.json'
         valid, data = dev._create_device_message_(config_file)
 
         # pin 1up values, has both optional values
@@ -156,7 +156,7 @@ class Ipac2DeviceTest(TestCase):
 
         dev.__class__ = Ipac2Device
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/ipac2/ipac2-pin-optional.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/ipac2/ipac2-pin-optional.json'
         # Validate against the base schema.
         resource_types = ['ipac2-pins']
         json_dict = dev.validate_config_base(config_file, resource_types)
@@ -185,12 +185,12 @@ class Ipac2DeviceTest(TestCase):
         self.assertTrue(dev)
         dev.__class__ = Ipac2Device
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/ipac2/ipac2-macro-large-count.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/ipac2/ipac2-macro-large-count.json'
         valid, data = dev._create_device_message_(config_file)
         self.assertFalse(valid)
         self.assertIsNone(data)
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/ipac2/ipac2-macro-large-action-count.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/ipac2/ipac2-macro-large-action-count.json'
         valid, data = dev._create_device_message_(config_file)
         self.assertFalse(valid)
         self.assertIsNone(data)
@@ -218,7 +218,7 @@ class Ipac2DeviceTest(TestCase):
 
         dev.__class__ = Ipac2Device
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/ipac2/ipac2-good.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/ipac2/ipac2-good.json'
         valid, data = dev._create_device_message_(config_file)
 
         header = PacConfigUnion()
@@ -228,7 +228,8 @@ class Ipac2DeviceTest(TestCase):
         # debounce is short (0x02)
         self.assertTrue(header.config.debounce == 0x02)
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/ipac2/ipac2-pin-optional.json')
+
+        config_file = Path(git_project_root()) / 'tests/test-data/ipac2/ipac2-pin-optional.json'
         valid, data = dev._create_device_message_(config_file)
 
         header = PacConfigUnion()

--- a/tests/devices/test_ipac4.py
+++ b/tests/devices/test_ipac4.py
@@ -3,8 +3,8 @@
 # file 'LICENSE', which is part of this source code package.
 #
 import json
-import os
 
+from pathlib import Path
 from unittest.mock import patch
 from unittest import TestCase
 
@@ -25,10 +25,10 @@ class Ipac4DeviceTest(TestCase):
         """ This is called before every test method in the test class """
         super(Ipac4DeviceTest, self).setUp()
 
-        schema_file = os.path.join(git_project_root(), 'ultimarc/schemas/ipac4.schema')
-        self.assertTrue(os.path.exists(schema_file))
-        config_file = os.path.join(git_project_root(), 'ultimarc/examples/ipac4.json')
-        self.assertTrue(os.path.exists(config_file))
+        schema_file = Path(git_project_root()) / 'ultimarc/schemas/ipac4.schema'
+        self.assertTrue(schema_file.is_file())
+        config_file = Path(git_project_root()) / 'ultimarc/examples/ipac4.json'
+        self.assertTrue(config_file.is_file())
 
         # https://python-jsonschema.readthedocs.io/en/stable/
         with open(schema_file) as h:
@@ -45,7 +45,7 @@ class Ipac4DeviceTest(TestCase):
 
         dev.__class__ = Ipac4Device
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/ipac4/ipac4-good.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/ipac4/ipac4-good.json'
         valid, data = dev._create_device_message_(config_file)
         # print(data)
         self.assertTrue(valid)
@@ -137,7 +137,7 @@ class Ipac4DeviceTest(TestCase):
 
         dev.__class__ = Ipac4Device
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/ipac4/ipac4-pin-optional.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/ipac4/ipac4-pin-optional.json'
         valid, data = dev._create_device_message_(config_file)
 
         # pin 3sw2 values, has both optional values
@@ -159,7 +159,7 @@ class Ipac4DeviceTest(TestCase):
 
         dev.__class__ = Ipac4Device
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/ipac4/ipac4-pin-optional.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/ipac4/ipac4-pin-optional.json'
         # Validate against the base schema.
         resource_types = ['ipac4-pins']
         json_dict = dev.validate_config_base(config_file, resource_types)
@@ -185,12 +185,12 @@ class Ipac4DeviceTest(TestCase):
         self.assertTrue(dev)
         dev.__class__ = Ipac4Device
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/ipac4/ipac4-macro-large-count.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/ipac4/ipac4-macro-large-count.json'
         valid, data = dev._create_device_message_(config_file)
         self.assertFalse(valid)
         self.assertIsNone(data)
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/ipac4/ipac4-macro-large-action-count.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/ipac4/ipac4-macro-large-action-count.json'
         valid, data = dev._create_device_message_(config_file)
         self.assertFalse(valid)
         self.assertIsNone(data)
@@ -218,7 +218,7 @@ class Ipac4DeviceTest(TestCase):
 
         dev.__class__ = Ipac4Device
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/ipac4/ipac4-good.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/ipac4/ipac4-good.json'
         valid, data = dev._create_device_message_(config_file)
 
         header = PacConfigUnion()
@@ -228,7 +228,7 @@ class Ipac4DeviceTest(TestCase):
         # debounce is long (0x03)
         self.assertTrue(header.config.debounce == 0x03)
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/ipac4/ipac4-pin-optional.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/ipac4/ipac4-pin-optional.json'
         valid, data = dev._create_device_message_(config_file)
 
         header = PacConfigUnion()

--- a/tests/devices/test_jpac.py
+++ b/tests/devices/test_jpac.py
@@ -3,8 +3,8 @@
 # file 'LICENSE', which is part of this source code package.
 #
 import json
-import os
 
+from pathlib import Path
 from unittest.mock import patch
 from unittest import TestCase
 
@@ -25,10 +25,10 @@ class JpacDeviceTest(TestCase):
         """ This is called before every test method in the test class """
         super(JpacDeviceTest, self).setUp()
 
-        schema_file = os.path.join(git_project_root(), 'ultimarc/schemas/jpac.schema')
-        self.assertTrue(os.path.exists(schema_file))
-        config_file = os.path.join(git_project_root(), 'ultimarc/examples/jpac.json')
-        self.assertTrue(os.path.exists(config_file))
+        schema_file = Path(git_project_root()) / 'ultimarc/schemas/jpac.schema'
+        self.assertTrue(schema_file.is_file())
+        config_file = Path(git_project_root()) / 'ultimarc/examples/jpac.json'
+        self.assertTrue(config_file.is_file())
 
         # https://python-jsonschema.readthedocs.io/en/stable/
         with open(schema_file) as h:
@@ -45,7 +45,7 @@ class JpacDeviceTest(TestCase):
 
         dev.__class__ = JpacDevice
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/jpac/jpac-good.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/jpac/jpac-good.json'
         valid, data = dev._create_device_message_(config_file)
         # print(data)
         self.assertTrue(valid)
@@ -146,7 +146,7 @@ class JpacDeviceTest(TestCase):
 
         dev.__class__ = JpacDevice
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/jpac/jpac-pin-optional.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/jpac/jpac-pin-optional.json'
         valid, data = dev._create_device_message_(config_file)
 
         # pin 1up values, has both optional values
@@ -171,7 +171,7 @@ class JpacDeviceTest(TestCase):
 
         dev.__class__ = JpacDevice
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/jpac/jpac-pin-optional.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/jpac/jpac-pin-optional.json'
         # Validate against the base schema.
         resource_types = ['jpac-pins']
         json_dict = dev.validate_config_base(config_file, resource_types)
@@ -200,12 +200,12 @@ class JpacDeviceTest(TestCase):
         self.assertTrue(dev)
         dev.__class__ = JpacDevice
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/jpac/jpac-macro-large-count.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/jpac/jpac-macro-large-count.json'
         valid, data = dev._create_device_message_(config_file)
         self.assertFalse(valid)
         self.assertIsNone(data)
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/jpac/jpac-macro-large-action-count.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/jpac/jpac-macro-large-action-count.json'
         valid, data = dev._create_device_message_(config_file)
         self.assertFalse(valid)
         self.assertIsNone(data)
@@ -233,7 +233,7 @@ class JpacDeviceTest(TestCase):
 
         dev.__class__ = JpacDevice
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/jpac/jpac-good.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/jpac/jpac-good.json'
         valid, data = dev._create_device_message_(config_file)
 
         header = PacConfigUnion()
@@ -243,7 +243,7 @@ class JpacDeviceTest(TestCase):
         # debounce is short (0x02)
         self.assertTrue(header.config.debounce == 0x02)
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/jpac/jpac-pin-optional.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/jpac/jpac-pin-optional.json'
         valid, data = dev._create_device_message_(config_file)
 
         header = PacConfigUnion()
@@ -263,7 +263,7 @@ class JpacDeviceTest(TestCase):
 
         dev.__class__ = JpacDevice
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/jpac/jpac-good.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/jpac/jpac-good.json'
         valid, data = dev._create_device_message_(config_file)
 
         # pin 1sw3 has 'disable' set to true

--- a/tests/devices/test_mini_pac.py
+++ b/tests/devices/test_mini_pac.py
@@ -4,6 +4,8 @@
 #
 import json
 import os
+
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -23,10 +25,10 @@ class MiniPacDeviceTest(TestCase):
         """ This is called before every test method in the test class """
         super(MiniPacDeviceTest, self).setUp()
 
-        schema_file = os.path.join(git_project_root(), 'ultimarc/schemas/mini-pac.schema')
-        self.assertTrue(os.path.exists(schema_file))
-        config_file = os.path.join(git_project_root(), 'ultimarc/examples/mini-pac.json')
-        self.assertTrue(os.path.exists(config_file))
+        schema_file = Path(git_project_root()) / 'ultimarc/schemas/mini-pac.schema'
+        self.assertTrue(schema_file.is_file())
+        config_file = Path(git_project_root()) / 'ultimarc/examples/mini-pac.json'
+        self.assertTrue(config_file.is_file())
 
         # https://python-jsonschema.readthedocs.io/en/stable/
         with open(schema_file) as h:
@@ -43,7 +45,7 @@ class MiniPacDeviceTest(TestCase):
 
         dev.__class__ = MiniPacDevice
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/minipac/mini-pac-good.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/minipac/mini-pac-good.json'
         valid, data = dev._create_message_(config_file)
         # print(data)
         self.assertTrue(valid)
@@ -121,7 +123,7 @@ class MiniPacDeviceTest(TestCase):
 
         dev.__class__ = MiniPacDevice
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/minipac/mini-pac-pin-optional.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/minipac/mini-pac-pin-optional.json'
         valid, data = dev._create_message_(config_file)
 
         # pin 1up values, has both optional values
@@ -146,7 +148,7 @@ class MiniPacDeviceTest(TestCase):
 
         dev.__class__ = MiniPacDevice
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/minipac/mini-pac-pin-optional.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/minipac/mini-pac-pin-optional.json'
         # Validate against the base schema.
         resource_types = ['mini-pac-pins']
         json_dict = dev.validate_config_base(config_file, resource_types)
@@ -175,12 +177,12 @@ class MiniPacDeviceTest(TestCase):
         self.assertTrue(dev)
         dev.__class__ = MiniPacDevice
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/minipac/mini-pac-macro-large-count.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/minipac/mini-pac-macro-large-count.json'
         valid, data = dev._create_message_(config_file)
         self.assertFalse(valid)
         self.assertIsNone(data)
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/minipac/mini-pac-macro-large-action-count.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/minipac/mini-pac-macro-large-action-count.json'
         valid, data = dev._create_message_(config_file)
         self.assertFalse(valid)
         self.assertIsNone(data)
@@ -208,7 +210,7 @@ class MiniPacDeviceTest(TestCase):
 
         dev.__class__ = MiniPacDevice
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/minipac/mini-pac-good.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/minipac/mini-pac-good.json'
         valid, data = dev._create_message_(config_file)
 
         header = PacConfigUnion()
@@ -218,7 +220,7 @@ class MiniPacDeviceTest(TestCase):
         # debounce is short (0x02)
         self.assertTrue(header.config.debounce == 0x02)
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/minipac/mini-pac-pin-optional.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/minipac/mini-pac-pin-optional.json'
         valid, data = dev._create_message_(config_file)
 
         header = PacConfigUnion()
@@ -238,7 +240,8 @@ class MiniPacDeviceTest(TestCase):
 
         dev.__class__ = MiniPacDevice
 
-        prev_dir = os.path.abspath(os.curdir)
-        os.chdir(os.path.abspath(__file__).split('/QtPyUltimarc/')[0])
+        git_path = Path(git_project_root())
+        outside_project = git_path.parent
+        os.chdir(outside_project)
         self.assertTrue(dev.load_config_schema('mini-pac.schema'))
-        os.chdir(prev_dir)
+        os.chdir(git_path)

--- a/tests/schemas/test_base_schema.py
+++ b/tests/schemas/test_base_schema.py
@@ -3,9 +3,9 @@
 # file 'LICENSE', which is part of this source code package.
 #
 import json
-import os
 import fastjsonschema
 
+from pathlib import Path
 from glob import glob
 
 from unittest import TestCase
@@ -19,14 +19,14 @@ class BaseSchemaTest(TestCase):
         """
         Test all example JSON configuration files against base.schema.
         """
-        schema_file = os.path.join(git_project_root(), 'ultimarc/schemas/base.schema')
-        self.assertTrue(os.path.exists(schema_file))
-        # https://python-jsonschema.readthedocs.io/en/stable/
+        schema_file = Path(git_project_root()) / 'ultimarc/schemas/base.schema'
+        self.assertTrue(schema_file.is_file())
+
         with open(schema_file) as h:
             schema = json.loads(h.read())
 
-        path = os.path.join(git_project_root(), 'ultimarc/examples/')
-        files = glob(os.path.join(path, "*.json"))
+        path = Path(git_project_root()) /  'ultimarc/examples/'
+        files = glob(Path(path / "*.json").__str__())
         for file in files:
             with open(file) as h:
                 config = json.loads(h.read())

--- a/tests/schemas/test_ipac2.py
+++ b/tests/schemas/test_ipac2.py
@@ -3,9 +3,9 @@
 # file 'LICENSE', which is part of this source code package.
 #
 import json
-import os
-
 import fastjsonschema
+
+from pathlib import Path
 from unittest import TestCase
 
 from ultimarc.system_utils import git_project_root
@@ -22,10 +22,10 @@ class Ipac2SchemaTest(TestCase):
         """ This is called before every test method in the test class """
         super(Ipac2SchemaTest, self).setUp()
 
-        schema_file = os.path.join(git_project_root(), 'ultimarc/schemas/ipac2.schema')
-        self.assertTrue(os.path.exists(schema_file))
-        config_file = os.path.join(git_project_root(), 'ultimarc/examples/ipac2.json')
-        self.assertTrue(os.path.exists(config_file))
+        schema_file = Path(git_project_root()) / 'ultimarc/schemas/ipac2.schema'
+        self.assertTrue(schema_file.is_file())
+        config_file = Path(git_project_root()) / 'ultimarc/examples/ipac2.json'
+        self.assertTrue(config_file.is_file())
 
         # https://python-jsonschema.readthedocs.io/en/stable/
         with open(schema_file) as h:
@@ -43,9 +43,8 @@ class Ipac2SchemaTest(TestCase):
         """ Test that bad json configurations fail against the ipac2 schema """
 
         # Macro entry
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/ipac2/ipac2-macro-bad.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/ipac2/ipac2-macro-bad.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())
@@ -54,9 +53,8 @@ class Ipac2SchemaTest(TestCase):
             self.config_validation(bad_config)
 
         # Pin entry
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/ipac2/ipac2-pin-bad.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/ipac2/ipac2-pin-bad.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())
@@ -65,9 +63,8 @@ class Ipac2SchemaTest(TestCase):
             self.config_validation(bad_config)
 
         # Debounce entry
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/ipac2/ipac2-debounce-bad.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/ipac2/ipac2-debounce-bad.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())
@@ -76,9 +73,8 @@ class Ipac2SchemaTest(TestCase):
             self.config_validation(bad_config)
 
         # Paclink entry
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/ipac2/ipac2-paclink-bad.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/ipac2/ipac2-paclink-bad.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())
@@ -89,9 +85,8 @@ class Ipac2SchemaTest(TestCase):
     def test_ipac2_optional_json(self):
         """ Test validation when optional entries are not present """
         # Macro entry
-        opt_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/ipac2/ipac2-pin-optional.json')
-        self.assertTrue(os.path.exists(opt_config_file))
+        opt_config_file = Path(git_project_root()) / 'tests/test-data/ipac2/ipac2-pin-optional.json'
+        self.assertTrue(opt_config_file.is_file())
 
         with open(opt_config_file) as h:
             opt_config = json.loads(h.read())

--- a/tests/schemas/test_ipac4.py
+++ b/tests/schemas/test_ipac4.py
@@ -3,9 +3,9 @@
 # file 'LICENSE', which is part of this source code package.
 #
 import json
-import os
-
 import fastjsonschema
+
+from pathlib import Path
 from unittest import TestCase
 
 from ultimarc.system_utils import git_project_root
@@ -22,10 +22,10 @@ class Ipac4SchemaTest(TestCase):
         """ This is called before every test method in the test class """
         super(Ipac4SchemaTest, self).setUp()
 
-        schema_file = os.path.join(git_project_root(), 'ultimarc/schemas/ipac4.schema')
-        self.assertTrue(os.path.exists(schema_file))
-        config_file = os.path.join(git_project_root(), 'ultimarc/examples/ipac4.json')
-        self.assertTrue(os.path.exists(config_file))
+        schema_file = Path(git_project_root()) / 'ultimarc/schemas/ipac4.schema'
+        self.assertTrue(schema_file.is_file())
+        config_file = Path(git_project_root()) / 'ultimarc/examples/ipac4.json'
+        self.assertTrue(config_file.is_file())
 
         # https://python-jsonschema.readthedocs.io/en/stable/
         with open(schema_file) as h:
@@ -43,9 +43,8 @@ class Ipac4SchemaTest(TestCase):
         """ Test that bad json configurations fail against the ipac4 schema """
 
         # Macro entry
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/ipac4/ipac4-macro-bad.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/ipac4/ipac4-macro-bad.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())
@@ -54,9 +53,8 @@ class Ipac4SchemaTest(TestCase):
             self.config_validation(bad_config)
 
         # Pin entry
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/ipac4/ipac4-pin-bad.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/ipac4/ipac4-pin-bad.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())
@@ -65,9 +63,8 @@ class Ipac4SchemaTest(TestCase):
             self.config_validation(bad_config)
 
         # Debounce entry
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/ipac4/ipac4-debounce-bad.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/ipac4/ipac4-debounce-bad.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())
@@ -76,9 +73,8 @@ class Ipac4SchemaTest(TestCase):
             self.config_validation(bad_config)
 
         # Paclink entry
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/ipac4/ipac4-paclink-bad.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/ipac4/ipac4-paclink-bad.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())
@@ -89,9 +85,8 @@ class Ipac4SchemaTest(TestCase):
     def test_ipac4_optional_json(self):
         """ Test validation when optional entries are not present """
         # Macro entry
-        opt_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/ipac4/ipac4-pin-optional.json')
-        self.assertTrue(os.path.exists(opt_config_file))
+        opt_config_file = Path(git_project_root()) / 'tests/test-data/ipac4/ipac4-pin-optional.json'
+        self.assertTrue(opt_config_file.is_file())
 
         with open(opt_config_file) as h:
             opt_config = json.loads(h.read())

--- a/tests/schemas/test_jpac.py
+++ b/tests/schemas/test_jpac.py
@@ -86,7 +86,7 @@ class JpacSchemaTest(TestCase):
         """ Test validation when optional entries are not present """
         # Macro entry
         opt_config_file = Path(git_project_root()) / 'tests/test-data/jpac/jpac-pin-optional.json'
-        self.assertTrue(os.path.exists(opt_config_file))
+        self.assertTrue(opt_config_file.is_file())
 
         with open(opt_config_file) as h:
             opt_config = json.loads(h.read())

--- a/tests/schemas/test_jpac.py
+++ b/tests/schemas/test_jpac.py
@@ -3,9 +3,9 @@
 # file 'LICENSE', which is part of this source code package.
 #
 import json
-import os
-
 import fastjsonschema
+
+from pathlib import Path
 from unittest import TestCase
 
 from ultimarc.system_utils import git_project_root
@@ -22,10 +22,10 @@ class JpacSchemaTest(TestCase):
         """ This is called before every test method in the test class """
         super(JpacSchemaTest, self).setUp()
 
-        schema_file = os.path.join(git_project_root(), 'ultimarc/schemas/jpac.schema')
-        self.assertTrue(os.path.exists(schema_file))
-        config_file = os.path.join(git_project_root(), 'ultimarc/examples/jpac.json')
-        self.assertTrue(os.path.exists(config_file))
+        schema_file = Path(git_project_root()) / 'ultimarc/schemas/jpac.schema'
+        self.assertTrue(schema_file.is_file())
+        config_file = Path(git_project_root()) / 'ultimarc/examples/jpac.json'
+        self.assertTrue(config_file.is_file())
 
         # https://python-jsonschema.readthedocs.io/en/stable/
         with open(schema_file) as h:
@@ -43,9 +43,8 @@ class JpacSchemaTest(TestCase):
         """ Test that bad json configurations fail against the jpac schema """
 
         # Macro entry
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/jpac/jpac-macro-bad.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/jpac/jpac-macro-bad.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())
@@ -54,9 +53,8 @@ class JpacSchemaTest(TestCase):
             self.config_validation(bad_config)
 
         # Pin entry
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/jpac/jpac-pin-bad.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/jpac/jpac-pin-bad.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())
@@ -65,9 +63,8 @@ class JpacSchemaTest(TestCase):
             self.config_validation(bad_config)
 
         # Debounce entry
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/jpac/jpac-debounce-bad.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/jpac/jpac-debounce-bad.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())
@@ -76,9 +73,8 @@ class JpacSchemaTest(TestCase):
             self.config_validation(bad_config)
 
         # Paclink entry
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/jpac/jpac-paclink-bad.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/jpac/jpac-paclink-bad.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())
@@ -89,8 +85,7 @@ class JpacSchemaTest(TestCase):
     def test_jpac_optional_json(self):
         """ Test validation when optional entries are not present """
         # Macro entry
-        opt_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/jpac/jpac-pin-optional.json')
+        opt_config_file = Path(git_project_root()) / 'tests/test-data/jpac/jpac-pin-optional.json'
         self.assertTrue(os.path.exists(opt_config_file))
 
         with open(opt_config_file) as h:
@@ -100,9 +95,8 @@ class JpacSchemaTest(TestCase):
 
     def test_jpac_disabled_pin(self):
         """ Test the 'disable' entry """
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/jpac/jpac-bad-disabled-pin.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/jpac/jpac-bad-disabled-pin.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())

--- a/tests/schemas/test_mini_pac.py
+++ b/tests/schemas/test_mini_pac.py
@@ -3,10 +3,10 @@
 # file 'LICENSE', which is part of this source code package.
 #
 import json
-import os
-from unittest import TestCase
-
 import fastjsonschema
+
+from pathlib import Path
+from unittest import TestCase
 
 from ultimarc.system_utils import git_project_root
 
@@ -21,10 +21,10 @@ class MiniPacSchemaTest(TestCase):
         """ This is called before every test method in the test class """
         super(MiniPacSchemaTest, self).setUp()
 
-        schema_file = os.path.join(git_project_root(), 'ultimarc/schemas/mini-pac.schema')
-        self.assertTrue(os.path.exists(schema_file))
-        config_file = os.path.join(git_project_root(), 'ultimarc/examples/mini-pac.json')
-        self.assertTrue(os.path.exists(config_file))
+        schema_file = Path(git_project_root()) / 'ultimarc/schemas/mini-pac.schema'
+        self.assertTrue(schema_file.is_file())
+        config_file = Path(git_project_root()) / 'ultimarc/examples/mini-pac.json'
+        self.assertTrue(config_file.is_file())
 
         # https://python-jsonschema.readthedocs.io/en/stable/
         with open(schema_file) as h:
@@ -42,9 +42,8 @@ class MiniPacSchemaTest(TestCase):
         """ Test that bad json configurations fail against the mini-pac schema """
 
         # Macro entry
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/minipac/mini-pac-macro-bad.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/minipac/mini-pac-macro-bad.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())
@@ -53,9 +52,8 @@ class MiniPacSchemaTest(TestCase):
             self.config_validation(bad_config)
 
         # Pin entry
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/minipac/mini-pac-pin-bad.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/minipac/mini-pac-pin-bad.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())
@@ -64,9 +62,8 @@ class MiniPacSchemaTest(TestCase):
             self.config_validation(bad_config)
 
         # Debounce entry
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/minipac/mini-pac-debounce-bad.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/minipac/mini-pac-debounce-bad.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())
@@ -75,9 +72,8 @@ class MiniPacSchemaTest(TestCase):
             self.config_validation(bad_config)
 
         # Paclink entry
-        bad_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/minipac/mini-pac-paclink-bad.json')
-        self.assertTrue(os.path.exists(bad_config_file))
+        bad_config_file = Path(git_project_root()) / 'tests/test-data/minipac/mini-pac-paclink-bad.json'
+        self.assertTrue(bad_config_file.is_file())
 
         with open(bad_config_file) as h:
             bad_config = json.loads(h.read())
@@ -88,9 +84,8 @@ class MiniPacSchemaTest(TestCase):
     def test_mini_pac_optional_json(self):
         """ Test validation when optional entries are not present """
         # Macro entry
-        opt_config_file = os.path.join(git_project_root(),
-                                       'tests/test-data/minipac/mini-pac-pin-optional.json')
-        self.assertTrue(os.path.exists(opt_config_file))
+        opt_config_file = Path(git_project_root()) / 'tests/test-data/minipac/mini-pac-pin-optional.json'
+        self.assertTrue(opt_config_file.is_file())
 
         with open(opt_config_file) as h:
             opt_config = json.loads(h.read())

--- a/tests/schemas/test_ultrastik.py
+++ b/tests/schemas/test_ultrastik.py
@@ -2,12 +2,13 @@
 # This file is subject to the terms and conditions defined in the
 # file 'LICENSE', which is part of this source code package.
 #
-from glob import glob
-import json
-import os
-from typing import List
 
+import json
 import fastjsonschema
+
+from pathlib import Path
+from typing import List
+from glob import glob
 
 from unittest import TestCase
 
@@ -37,19 +38,18 @@ class UltraStikSchemaTest(TestCase):
         self.invalid_config_files = []
         self.invalid_controller_id_config_files = []
 
-        schema_root = os.path.join(git_project_root(), 'ultimarc/schemas')
-        test_config_root = os.path.join(git_project_root(), 'tests/test-data/ultrastik')
-        self.assertTrue(os.path.exists(test_config_root))
-        example_config_root = os.path.join(git_project_root(), 'ultimarc/examples')
-        self.assertTrue(os.path.exists(example_config_root))
+        test_config_root = Path(git_project_root()) / 'tests/test-data/ultrastik'
+        self.assertTrue(test_config_root.is_dir())
+        example_config_root = Path(git_project_root()) / 'ultimarc/examples'
+        self.assertTrue(example_config_root.is_dir())
 
         # Load UltraStik schema files
-        config_schema_file = os.path.join(schema_root, 'ultrastik-config.schema')
-        self.assertTrue(os.path.exists(config_schema_file))
-        controller_schema_file = os.path.join(schema_root, 'ultrastik-controller-id.schema')
-        self.assertTrue(os.path.exists(controller_schema_file))
+        schema_dir = Path(git_project_root()) / 'ultimarc/schemas'
+        config_schema_file = Path(git_project_root()) / schema_dir / 'ultrastik-config.schema'
+        self.assertTrue(config_schema_file.is_file())
+        controller_schema_file = Path(git_project_root()) / schema_dir / 'ultrastik-controller-id.schema'
+        self.assertTrue(controller_schema_file.is_file())
 
-        # https://python-jsonschema.readthedocs.io/en/stable/
         with open(config_schema_file) as h:
             self.ultrastik_config_schema = json.loads(h.read())
         with open(controller_schema_file) as h:
@@ -59,7 +59,7 @@ class UltraStikSchemaTest(TestCase):
         self.controller_id_config_validation = fastjsonschema.compile(self.ultrastik_controller_id_config_schema)
 
         # Load list of invalid config files
-        invalid_config_files = glob(os.path.join(test_config_root, 'ultrastik_*.json'))
+        invalid_config_files = glob((test_config_root / 'ultrastik_*.json').__str__())
 
         # Load the invalid config test files and sort them by ResourceType value.
         for file in invalid_config_files:
@@ -76,7 +76,7 @@ class UltraStikSchemaTest(TestCase):
         self.assertIsNotNone(self.invalid_controller_id_config_files)
 
         # Load list of example config files and sort them by ResourceType value.
-        valid_config_files = glob(os.path.join(example_config_root, 'ultrastik-*.json'))
+        valid_config_files = glob((example_config_root / 'ultrastik-*.json').__str__())
         for file in valid_config_files:
             with open(file) as h:
                 config = h.read()
@@ -127,7 +127,6 @@ class UltraStikSchemaTest(TestCase):
 
         for file in self.invalid_config_files:
             with open(file) as h:
-                print(file)
                 bad_config = json.loads(h.read())
                 with self.assertRaises(fastjsonschema.JsonSchemaValueException):
                     self.config_validation(bad_config)

--- a/tests/schemas/test_usb_button.py
+++ b/tests/schemas/test_usb_button.py
@@ -3,9 +3,9 @@
 # file 'LICENSE', which is part of this source code package.
 #
 import json
-import os
-
 import fastjsonschema
+
+from pathlib import Path
 from unittest import TestCase
 
 from ultimarc.system_utils import git_project_root
@@ -22,10 +22,10 @@ class USBButtonSchemaTest(TestCase):
         """ This is called before every test method in the test class. """
         super(USBButtonSchemaTest, self).setUp()
 
-        schema_file = os.path.join(git_project_root(), 'ultimarc/schemas/usb-button-color.schema')
-        self.assertTrue(os.path.exists(schema_file))
-        config_file = os.path.join(git_project_root(), 'ultimarc/examples/usb-button-color.json')
-        self.assertTrue(os.path.exists(config_file))
+        schema_file = Path(git_project_root()) / 'ultimarc/schemas/usb-button-color.schema'
+        self.assertTrue(schema_file.is_file())
+        config_file = Path(git_project_root()) / 'ultimarc/examples/usb-button-color.json'
+        self.assertTrue(config_file.is_file())
 
         # https://python-jsonschema.readthedocs.io/en/stable/
         with open(schema_file) as h:

--- a/tests/schemas/test_usb_device_handle.py
+++ b/tests/schemas/test_usb_device_handle.py
@@ -2,9 +2,7 @@
 # This file is subject to the terms and conditions defined in the
 # file 'LICENSE', which is part of this source code package.
 #
-import os
-import logging
-
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -22,9 +20,9 @@ class USBDeviceHandleTest(TestCase):
         dev = USBDeviceHandle('test_handle', '0000:0000')
         self.assertTrue(dev)
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/usb-button/usb-button-color-good.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/usb-button/usb-button-color-good.json'
         self.assertTrue(dev.validate_config_base(config_file, ['usb-button-color']))
         self.assertIsNone(dev.validate_config_base(config_file, ['bad-resource-type']))
 
-        config_file = os.path.join(git_project_root(), 'tests/test-data/usb-button/usb-button-color-bad.json')
+        config_file = Path(git_project_root()) / 'tests/test-data/usb-button/usb-button-color-bad.json'
         self.assertIsNone(dev.validate_config_base(config_file, ['usb-button-color']))

--- a/ultimarc/devices/_device.py
+++ b/ultimarc/devices/_device.py
@@ -8,9 +8,10 @@
 import ctypes as ct
 import json
 import logging
-import os
+
 from enum import IntEnum
 from json import JSONDecodeError
+from pathlib import Path
 
 import fastjsonschema
 import libusb as usb
@@ -401,12 +402,13 @@ class USBDeviceHandle:
         :param schema_file: Schema file name only, no path included.
         :return: schema dict.
         """
-        proj_path = os.path.abspath(__file__).split('/ultimarc/')[0]
-        import_base = os.path.join(proj_path, 'ultimarc')
-        schema_base = os.path.join(import_base, 'schemas')
-        schema_path = os.path.abspath(os.path.join(schema_base, schema_file))
+        file_path = Path.resolve(Path(__file__))
+        proj_path = file_path.parents[2]
+        import_base = proj_path / 'ultimarc'
+        schema_base = import_base / 'schemas'
+        schema_path = schema_base / schema_file
 
-        if not schema_path:
+        if not schema_path.is_file():
             _logger.error(_('Unable to locate schema directory.'))
             return None
 

--- a/ultimarc/main.py
+++ b/ultimarc/main.py
@@ -6,11 +6,13 @@ import logging
 import os
 import sys
 
+from pathlib import Path
+
 from ultimarc.ui.device_model import DeviceModel
 
 try:
     from PySide6.QtQuickControls2 import QQuickStyle
-    from PySide6.QtCore import QCoreApplication
+    from PySide6.QtCore import QCoreApplication, QUrl
     from PySide6.QtGui import QGuiApplication
     from PySide6.QtQml import QQmlApplicationEngine
 except ImportError:
@@ -35,10 +37,11 @@ _tool_version = _('1.0.0-alpha.7')
 
 
 def run():
-    proj_path = os.path.abspath(__file__).split('/ultimarc/')[0]
-    app_base = os.path.join(proj_path, 'ultimarc')
+    file_path = Path.resolve(Path(__file__))
+    proj_path = file_path.parents[1]
+    app_base = file_path.parents[0]
 
-    os.environ['PYTHONPATH'] = proj_path
+    os.environ['PYTHONPATH'] = proj_path.__str__()
 
     """ Main UI entry point """
     app = QGuiApplication(sys.argv)
@@ -57,7 +60,7 @@ def run():
     QCoreApplication.setApplicationName(_tool_title)
 
     engine = QQmlApplicationEngine()
-    engine.addImportPath(app_base)
+    engine.addImportPath(app_base.__str__())
 
     with ToolContextManager(_tool_cmd, args) as tool_env:
         # Local class instantiation
@@ -79,6 +82,7 @@ def run():
         context.setContextProperty('_units', units)
 
         engine.loadFromModule('qml', 'Main')
+
         if not engine.rootObjects():
             _logger.error(_('Bad UI settings found, aborting.'))
             sys.exit(-1)

--- a/ultimarc/tools/__init__.py
+++ b/ultimarc/tools/__init__.py
@@ -7,6 +7,7 @@ import logging
 import os.path
 import sys
 import traceback
+import platform
 
 from ultimarc import translate_gettext as _
 from ultimarc.devices import USBDevices
@@ -68,11 +69,12 @@ class ToolContextManager(object):
             'devices': USBDevices(_VENDOR_FILTER)
         }
 
-        write_pidfile_or_die(command)
+        if platform.system() == 'Linux':
+            write_pidfile_or_die(command)
 
-        if not self._env:
-            remove_pidfile(command)
-            exit(1)
+            if not self._env:
+                remove_pidfile(command)
+                exit(1)
 
     def __enter__(self):
         """ Return object with properties set to config values """


### PR DESCRIPTION
Remove methods that were not being used.  Checked for Linux before looking for pid files.  Move away from os library to pathlib when accessing paths to schema and configuration files.  Updated test files to use pathlib.  Updated README to give guidance when installing on Windows.